### PR TITLE
Update gatsby devDependencies 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "4.1.3",
   "description": "Minify CSS Modules class names",
   "repository": "https://github.com/stldo/gatsby-plugin-minify-classnames",
+  "engines": {
+    "yarn": "^1.17.3",
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
   "keywords": [
     "gatsby",
     "gatsby-plugin",
@@ -23,14 +28,14 @@
     "incstr": "^1.2.3"
   },
   "devDependencies": {
-    "eslint": "^8.8.0",
+    "eslint": "^8.29.0",
     "eslint-config-standard": "^17.0.0-0",
-    "eslint-plugin-import": "^2.25.4",
+    "eslint-plugin-import": "^2.26",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0"
   },
   "peerDependencies": {
-    "gatsby": "^4.0.0"
+    "gatsby": "^5.0.0"
   },
   "author": "stldo (https://github.com/stldo)",
   "license": "MIT"


### PR DESCRIPTION
Changed the `devDependencies` to `5.x` and added the section to specify the correct `nodejs` version that Gatsby uses, which is 18.